### PR TITLE
Databinding solucionado

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,9 +2,13 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Comandix.iml" filepath="$PROJECT_DIR$/.idea/Comandix.iml" />
       <module fileurl="file://$PROJECT_DIR$/Comandix.iml" filepath="$PROJECT_DIR$/Comandix.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/commons/commons.iml" filepath="$PROJECT_DIR$/commons/commons.iml" />
+      <module fileurl="file://$PROJECT_DIR$/commons/commons.iml" filepath="$PROJECT_DIR$/commons/commons.iml" />
+      <module fileurl="file://$PROJECT_DIR$/domain/domain.iml" filepath="$PROJECT_DIR$/domain/domain.iml" />
       <module fileurl="file://$PROJECT_DIR$/domain/domain.iml" filepath="$PROJECT_DIR$/domain/domain.iml" />
     </modules>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/a630465/comandix/adapters/DishAdapter.kt
+++ b/app/src/main/java/com/example/a630465/comandix/adapters/DishAdapter.kt
@@ -1,0 +1,25 @@
+package com.example.a630465.comandix.adapters
+
+import android.databinding.DataBindingUtil
+import android.databinding.ViewDataBinding
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.example.a630465.comandix.BR
+import com.example.a630465.comandix.R
+import com.example.a630465.comandix.utils.Handlers
+import com.example.commons.DataBindingRecyclerAdapter
+import com.example.commons.DataBindingViewHolder
+import com.example.domain.model.Dish
+import com.example.domain.model.Table
+
+/**
+ * Created by diego.francisco on 25/01/2018.
+ */
+class DishAdapter(private val presenter: Handlers) : DataBindingRecyclerAdapter<Dish>(BR.dish, R.layout.item_dish) {
+
+    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): DishViewHolder {
+        val viewDatabinding: ViewDataBinding = DataBindingUtil.inflate(LayoutInflater.from(parent!!.context), R.layout.item_table, parent, false)
+        return DishViewHolder(viewDatabinding, presenter)
+    }
+
+}

--- a/app/src/main/java/com/example/a630465/comandix/adapters/DishViewHolder.kt
+++ b/app/src/main/java/com/example/a630465/comandix/adapters/DishViewHolder.kt
@@ -1,0 +1,21 @@
+package com.example.a630465.comandix.adapters
+
+import android.databinding.ViewDataBinding
+import com.example.a630465.comandix.BR
+import com.example.a630465.comandix.utils.Handlers
+import com.example.commons.DataBindingViewHolder
+import com.example.domain.model.Dish
+import com.example.domain.model.Table
+
+/**
+ * Created by diego.francisco on 25/01/2018.
+ */
+class DishViewHolder(val viewDataBinding: ViewDataBinding,
+                     val presenter: Handlers) : DataBindingViewHolder<Dish>(BR.dish, viewDataBinding) {
+
+    override fun bindItem(item: Dish) {
+        super.bindItem(item)
+        viewDataBinding.setVariable(BR.presenter, presenter)
+    }
+
+}

--- a/app/src/main/java/com/example/a630465/comandix/adapters/TableAdapter.kt
+++ b/app/src/main/java/com/example/a630465/comandix/adapters/TableAdapter.kt
@@ -1,0 +1,24 @@
+package com.example.a630465.comandix.adapters
+
+import android.databinding.DataBindingUtil
+import android.databinding.ViewDataBinding
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.example.a630465.comandix.BR
+import com.example.a630465.comandix.R
+import com.example.a630465.comandix.utils.Handlers
+import com.example.commons.DataBindingRecyclerAdapter
+import com.example.commons.DataBindingViewHolder
+import com.example.domain.model.Table
+
+/**
+ * Created by diego.francisco on 25/01/2018.
+ */
+class TableAdapter(private val presenter: Handlers) : DataBindingRecyclerAdapter<Table>(BR.table, R.layout.item_table) {
+
+    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): DataBindingViewHolder<Table> {
+        val viewDatabinding: ViewDataBinding = DataBindingUtil.inflate(LayoutInflater.from(parent!!.context), R.layout.item_table, parent, false)
+        return TableViewHolder(viewDatabinding, presenter)
+    }
+
+}

--- a/app/src/main/java/com/example/a630465/comandix/adapters/TableViewHolder.kt
+++ b/app/src/main/java/com/example/a630465/comandix/adapters/TableViewHolder.kt
@@ -1,0 +1,20 @@
+package com.example.a630465.comandix.adapters
+
+import android.databinding.ViewDataBinding
+import com.example.a630465.comandix.BR
+import com.example.a630465.comandix.utils.Handlers
+import com.example.commons.DataBindingViewHolder
+import com.example.domain.model.Table
+
+/**
+ * Created by diego.francisco on 25/01/2018.
+ */
+class TableViewHolder(val viewDataBinding: ViewDataBinding,
+                      val presenter: Handlers) : DataBindingViewHolder<Table>(BR.table, viewDataBinding) {
+
+    override fun bindItem(item: Table) {
+        super.bindItem(item)
+        viewDataBinding.setVariable(BR.presenter, presenter)
+    }
+
+}

--- a/app/src/main/java/com/example/a630465/comandix/fragments/BillFragment.kt
+++ b/app/src/main/java/com/example/a630465/comandix/fragments/BillFragment.kt
@@ -8,9 +8,9 @@ import com.example.commons.BaseListFragment
 import com.example.commons.DataBindingRecyclerAdapter
 
 
-class BillFragment : BaseListFragment() {
+class BillFragment {
 
-    override fun setupList(list: RecyclerView) {
+    /*override fun setupList(list: RecyclerView) {
         super.setupList(list)
     }
 
@@ -33,5 +33,6 @@ class BillFragment : BaseListFragment() {
                                     "https://ep01.epimg.net/elcomidista/imagenes/2017/03/28/receta/1490731468_626097_1490731646_media_normal.jpg",
                                     12.50f))
     }
+    */
 
 }

--- a/app/src/main/java/com/example/a630465/comandix/fragments/DishesFragment.kt
+++ b/app/src/main/java/com/example/a630465/comandix/fragments/DishesFragment.kt
@@ -3,6 +3,8 @@ package com.example.a630465.comandix.fragments
 import android.support.v7.widget.RecyclerView
 import com.example.a630465.comandix.BR
 import com.example.a630465.comandix.R
+import com.example.a630465.comandix.adapters.DishAdapter
+import com.example.a630465.comandix.utils.Handlers
 import com.example.domain.model.*
 import com.example.commons.BaseListFragment
 import com.example.commons.DataBindingRecyclerAdapter
@@ -11,7 +13,7 @@ import com.example.commons.DataBindingRecyclerAdapter
 class DishesFragment : BaseListFragment() {
 
     override fun getAdapter(): RecyclerView.Adapter<*> {
-        val dishAdapter = DataBindingRecyclerAdapter<Dish>(BR.dish, R.layout.item_dish)
+        val dishAdapter = DishAdapter(Handlers())
         dishAdapter.items.addAll(getDishes())
         dishAdapter.notifyDataSetChanged()
         return dishAdapter

--- a/app/src/main/java/com/example/a630465/comandix/fragments/TableFragment.kt
+++ b/app/src/main/java/com/example/a630465/comandix/fragments/TableFragment.kt
@@ -3,6 +3,8 @@ package com.example.a630465.comandix.fragments
 import android.support.v7.widget.RecyclerView
 import com.example.a630465.comandix.BR
 import com.example.a630465.comandix.R
+import com.example.a630465.comandix.adapters.TableAdapter
+import com.example.a630465.comandix.utils.Handlers
 import com.example.domain.model.*
 import com.example.commons.BaseListFragment
 import com.example.commons.DataBindingRecyclerAdapter
@@ -15,7 +17,7 @@ class TableFragment : BaseListFragment() {
     }
 
     override fun getAdapter(): RecyclerView.Adapter<*> {
-        val tablesAdapter = DataBindingRecyclerAdapter<Table>(BR.table, R.layout.item_table)
+        val tablesAdapter = TableAdapter(Handlers())
         tablesAdapter.updateItems(getTables())
 
         return tablesAdapter

--- a/app/src/main/res/layout/item_table.xml
+++ b/app/src/main/res/layout/item_table.xml
@@ -17,13 +17,16 @@
     <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="100dp"
-        app:cardBackgroundColor="@color/colorPrimary">
+        app:cardBackgroundColor="@color/colorPrimary"
+        android:onClick="@{() -> presenter.showOrderForTable(table)}"
+        android:clickable="true"
+        android:focusable="true"
+        android:foreground="?attr/selectableItemBackground">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="8dp"
-            android:onClick="@{() -> presenter.showOrderForTable(table)}">
+            android:padding="8dp">
 
             <ImageView
                 android:id="@+id/imgTable"

--- a/commons/src/main/java/com/example/commons/DataBindingRecyclerAdapter.kt
+++ b/commons/src/main/java/com/example/commons/DataBindingRecyclerAdapter.kt
@@ -8,35 +8,24 @@ import android.view.ViewGroup
 
 //Adaptador genérico, recibe un modelo de datos con el que vamos a trabajar,
 // que es el mismo que se le pasará al ViewHolder y el mismo modelo que se usará para crear la lista
+abstract class DataBindingRecyclerAdapter<MODEL>(private val bindingVarId: Int,
+                                             private val viewHolderResId: Int) : RecyclerView.Adapter<DataBindingViewHolder<MODEL>>() {
 
- class DataBindingRecyclerAdapter <MODEL>(val bindingVarId: Int, val viewHolderResId: Int) : RecyclerView.Adapter<DataBindingViewHolder<MODEL>>() {
-
-    var items : MutableList<MODEL> = mutableListOf()
+    var items: MutableList<MODEL> = mutableListOf()
 
     //Saber cuántos item va a tener
     override fun getItemCount(): Int = items.size
 
-    //Crear la vista de los items, para ello usa el id del layout especificado cuando lo llamamos
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DataBindingViewHolder<MODEL> {
-        val binding : ViewDataBinding = DataBindingUtil.inflate(LayoutInflater.from(parent.context),
-                                                                                    viewHolderResId,
-                                                                                    parent,
-                                                                                    false)
-
-        return DataBindingViewHolder(bindingVarId, binding)
-    }
-
-     //Configura el contenido de la view con el item obtenido en la posición especificada
+    //Configura el contenido de la view con el item obtenido en la posición especificada
     override fun onBindViewHolder(holder: DataBindingViewHolder<MODEL>, position: Int) {
         val item = items[position]
         holder.bindItem(item)
     }
 
-     //Añade todos los items y notifica el cambio
-     fun updateItems(tables: ArrayList<MODEL>) {
-         items.addAll(tables)
-         notifyDataSetChanged()
-     }
+    //Añade todos los items y notifica el cambio
+    fun updateItems(tables: ArrayList<MODEL>) {
+        items.addAll(tables)
+        notifyDataSetChanged()
+    }
 
-
- }
+}

--- a/commons/src/main/java/com/example/commons/DataBindingViewHolder.kt
+++ b/commons/src/main/java/com/example/commons/DataBindingViewHolder.kt
@@ -5,11 +5,13 @@ import android.support.v7.widget.RecyclerView
 
 //ViewHolder genérico que recibe un modelo y el binding.
 // A través del binding accdemos a la vista raíz
-class DataBindingViewHolder<MODEL>(val bindingVarId: Int, val binding :  ViewDataBinding) : RecyclerView.ViewHolder(binding.root){
+open class DataBindingViewHolder<MODEL>(val bindingVarId: Int, val binding:  ViewDataBinding) : RecyclerView.ViewHolder(binding.root){
 
-    fun bindItem(item: MODEL){
+    open fun bindItem(item: MODEL){
         binding.setVariable(bindingVarId, item)
+
         //Forzar para que le binding se haga automáticamente y en el mismo momento
         binding.executePendingBindings()
     }
+
 }


### PR DESCRIPTION
Te he creado un sub-adapter por cada adapter, haciendo el padre abstracto. Está bien intentar reutilizar el mayor código posible, sin embargo, reutilizar una única clase para todo tipo de items es prácticamente muy complicado.

Por tanto, he intentado mantener lo máximo posible la implementación que ya tenías y le he dado un giro de tuercas.

Espero que entiendas a lo que me refería, básicamente tenías que añadir la variable presenter con el respecto objeto de la clase Handlers.

Eso sí, ahora te faltaría crear una interface o una high-order function con Kotlin para pasar el resultado a la vista y que ésta llame al navigator para que abra la activity detail de ese item.

También he hecho unos pequeños arreglos al CardView para que muestre un ripple cuando pulsas sobre él. Que, por cierto, en ese tipo de item_list no necesitas un cardview, carece de sentido pues el propio constraint-layout puede hacer lo mismo y ahorras un viewgroup que lo único que hará es consumir más RAM y tiempo de inflado de la vista.